### PR TITLE
reorder import of serializers to fix chunk loading in dev

### DIFF
--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -57,6 +57,6 @@ module.exports = {
             },
         },
         `gatsby-plugin-react-helmet`,
-        `gatsby-plugin-sass`
+        `gatsby-plugin-sass`,
     ],
 }

--- a/web/src/pages/about.tsx
+++ b/web/src/pages/about.tsx
@@ -3,13 +3,13 @@ import { graphql } from 'gatsby'
 import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 import { Helmet } from 'react-helmet'
 import BlockContent from '@sanity/block-content-to-react'
-import serializers from '../components/serializers'
 import Layout from '../components/Layout'
 import { SanityCreator, SanityEmployer } from '../../graphql-types'
 import EmploymentHistoryList from '../components/about/EmploymentHistoryList'
-import * as styles from './about.module.scss'
+import serializers from '../components/serializers'
 import ghLogo from '../images/octocat-logo.png'
 import linkedInLogo from '../images/linkedin-logo.png'
+import * as styles from './about.module.scss'
 
 export const query = graphql`
 query{


### PR DESCRIPTION
This PR fixes an issue **that would only occur in develop mode** (e.g., when the files are being watched for changes).

This issue happened because the `serializers` import was in the incorrect spot in the imports list and would lead to a conflict in how webpack resolved the chunks. This change fixes the issue.

## Later...

We should set up linting to handle sorting the imports for us, but I'm not in that headspace at the moment.